### PR TITLE
Add screen recording support to auto scroller extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# codex
+# Auto Scroller Chrome Extension
+
+This repository contains a Chrome extension that lets you open any URL, automatically scroll through the page at a custom speed, and capture a recording of the session.
+
+## Usage
+
+1. Load the extension in Chrome by visiting `chrome://extensions`, enabling **Developer mode**, and choosing **Load unpacked**.
+2. Select this project folder.
+3. Open the popup, provide the target page URL and scroll speed (in pixels per second), and start the auto-scroll.
+4. Keep the popup open until you see a status message that the recording is complete and a `.webm` download begins.
+
+The extension opens the provided URL in the current window (reusing a blank new-tab page when possible), records the active tab, and scrolls until the bottom of the page is reached. When scrolling finishes, a WebM video file is downloaded automatically.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "Auto Scroller",
+  "version": "1.0",
+  "description": "Scroll a page automatically at a custom speed after opening a URL.",
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Auto Scroller"
+  },
+  "permissions": [
+    "scripting",
+    "tabs",
+    "tabCapture",
+    "downloads"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ]
+}

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,71 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background: linear-gradient(145deg, #1f2937, #111827);
+  color: #f9fafb;
+}
+
+.container {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.25rem;
+  text-align: center;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.label {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.input {
+  width: 100%;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 0.6rem 0.75rem;
+  background-color: rgba(17, 24, 39, 0.7);
+  color: inherit;
+}
+
+.input:focus {
+  outline: 2px solid #60a5fa;
+  outline-offset: 1px;
+}
+
+.button {
+  padding: 0.65rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.35);
+}
+
+.status {
+  min-height: 1.25rem;
+  font-size: 0.8rem;
+  opacity: 0.85;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Auto Scroller</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1 class="title">Auto Scroller</h1>
+      <form id="scrollForm" class="form">
+        <label class="label" for="url">Page URL</label>
+        <input
+          id="url"
+          name="url"
+          type="url"
+          placeholder="https://example.com"
+          required
+          class="input"
+        />
+
+        <label class="label" for="speed">Scroll speed (pixels / second)</label>
+        <input
+          id="speed"
+          name="speed"
+          type="number"
+          min="1"
+          step="1"
+          value="200"
+          required
+          class="input"
+        />
+
+        <button type="submit" class="button">Start scrolling</button>
+        <p id="status" class="status" role="status" aria-live="polite"></p>
+      </form>
+    </main>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,244 @@
+const form = document.getElementById('scrollForm');
+const statusEl = document.getElementById('status');
+
+const recorderState = {
+  mediaRecorder: null,
+  chunks: [],
+  stream: null,
+  stopPromise: null,
+  resolveStop: null,
+  stopHandler: null
+};
+
+function setStatus(message, isError = false) {
+  statusEl.textContent = message;
+  statusEl.style.color = isError ? '#f87171' : '#a5b4fc';
+}
+
+async function createOrUpdateTab(url) {
+  const [currentTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+  if (currentTab && currentTab.url === 'chrome://newtab/') {
+    return chrome.tabs.update(currentTab.id, { url });
+  }
+
+  return chrome.tabs.create({ url, active: true });
+}
+
+function resetRecorderState() {
+  if (recorderState.stream) {
+    recorderState.stream.getTracks().forEach((track) => track.stop());
+  }
+
+  recorderState.mediaRecorder = null;
+  recorderState.chunks = [];
+  recorderState.stream = null;
+  recorderState.stopPromise = null;
+  recorderState.resolveStop = null;
+  recorderState.stopHandler = null;
+}
+
+function downloadRecording() {
+  if (!recorderState.chunks.length) {
+    return Promise.resolve();
+  }
+
+  const blob = new Blob(recorderState.chunks, { type: 'video/webm' });
+
+  const timestamp = new Date().toISOString().replace(/[.:]/g, '-');
+  const filename = `auto-scroll-${timestamp}.webm`;
+  const url = URL.createObjectURL(blob);
+
+  return new Promise((resolve) => {
+    chrome.downloads.download({ url, filename }, () => {
+      if (chrome.runtime.lastError) {
+        console.error('Failed to start download:', chrome.runtime.lastError.message);
+      }
+
+      setTimeout(() => URL.revokeObjectURL(url), 30_000);
+      resolve();
+    });
+  });
+}
+
+function startRecording() {
+  if (recorderState.mediaRecorder) {
+    return recorderState.stopPromise || Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    chrome.tabCapture.capture({ audio: false, video: true }, (stream) => {
+      if (chrome.runtime.lastError || !stream) {
+        reject(
+          new Error(
+            chrome.runtime.lastError?.message || 'Unable to capture the current tab.'
+          )
+        );
+        return;
+      }
+
+      recorderState.stream = stream;
+      recorderState.chunks = [];
+
+      try {
+        const mediaRecorder = new MediaRecorder(stream, {
+          mimeType: 'video/webm;codecs=vp9'
+        });
+
+        const stopPromise = new Promise((resolveStop) => {
+          recorderState.resolveStop = resolveStop;
+        });
+
+        recorderState.stopPromise = stopPromise;
+
+        let handled = false;
+
+        const handleStop = async () => {
+          if (handled) {
+            return;
+          }
+
+          handled = true;
+          mediaRecorder.removeEventListener('stop', handleStop);
+          mediaRecorder.removeEventListener('error', handleError);
+
+          const resolveStop = recorderState.resolveStop;
+          await downloadRecording();
+          resetRecorderState();
+          resolveStop?.();
+        };
+
+        const handleError = (event) => {
+          console.error('MediaRecorder error:', event.error);
+          handleStop();
+        };
+
+        mediaRecorder.addEventListener('dataavailable', (event) => {
+          if (event.data && event.data.size > 0) {
+            recorderState.chunks.push(event.data);
+          }
+        });
+
+        mediaRecorder.addEventListener('stop', handleStop);
+        mediaRecorder.addEventListener('error', handleError);
+
+        recorderState.mediaRecorder = mediaRecorder;
+        recorderState.stopHandler = handleStop;
+        mediaRecorder.start(1000);
+        resolve();
+      } catch (error) {
+        console.error('Failed to start recorder:', error);
+        stream.getTracks().forEach((track) => track.stop());
+        reject(error);
+      }
+    });
+  });
+}
+
+function stopRecording() {
+  if (!recorderState.mediaRecorder) {
+    return Promise.resolve();
+  }
+
+  const { mediaRecorder, stopPromise } = recorderState;
+
+  if (mediaRecorder.state === 'inactive') {
+    recorderState.stopHandler?.();
+    return stopPromise || Promise.resolve();
+  }
+
+  try {
+    mediaRecorder.stop();
+  } catch (error) {
+    console.error('Failed to stop recorder cleanly:', error);
+    recorderState.stopHandler?.();
+  }
+
+  return stopPromise || Promise.resolve();
+}
+
+async function startAutoScroll(tabId, speed) {
+  const [result] = await chrome.scripting.executeScript({
+    target: { tabId },
+    func: (pixelsPerSecond) => {
+      const state = (window.__autoScrollState = window.__autoScrollState || {});
+
+      if (state.rafId) {
+        cancelAnimationFrame(state.rafId);
+      }
+
+      if (state.resolve) {
+        state.resolve();
+      }
+
+      state.lastTimestamp = null;
+
+      return new Promise((resolve) => {
+        state.resolve = resolve;
+
+        const scrollStep = (timestamp) => {
+          if (!state.lastTimestamp) {
+            state.lastTimestamp = timestamp;
+          }
+
+          const elapsed = timestamp - state.lastTimestamp;
+          const distance = (pixelsPerSecond * elapsed) / 1000;
+
+          const maxScroll =
+            document.documentElement.scrollHeight - window.innerHeight;
+          const currentScroll = window.scrollY;
+          const nextScroll = Math.min(currentScroll + distance, maxScroll);
+
+          window.scrollTo({ top: nextScroll, behavior: 'auto' });
+          state.lastTimestamp = timestamp;
+
+          if (nextScroll >= maxScroll) {
+            state.rafId = null;
+            state.lastTimestamp = null;
+            state.resolve = null;
+            resolve();
+            return;
+          }
+
+          state.rafId = requestAnimationFrame(scrollStep);
+        };
+
+        state.rafId = requestAnimationFrame(scrollStep);
+      });
+    },
+    args: [speed]
+  });
+
+  return result?.result;
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  const formData = new FormData(form);
+  const url = formData.get('url');
+  const speed = Number(formData.get('speed'));
+
+  if (!url || Number.isNaN(speed) || speed <= 0) {
+    setStatus('Please provide a valid URL and scroll speed.', true);
+    return;
+  }
+
+  setStatus('Opening tab and preparing scroll…');
+
+  try {
+    const tab = await createOrUpdateTab(url);
+
+    await new Promise((resolve) => setTimeout(resolve, 750));
+
+    await startRecording();
+    setStatus('Auto-scroll and recording started. Keep this popup open until the download begins.');
+    await startAutoScroll(tab.id, speed);
+    await stopRecording();
+    setStatus('Auto-scroll complete. A video download should have started.');
+  } catch (error) {
+    console.error(error);
+    setStatus('Failed to start auto-scroll. Check console for details.', true);
+    await stopRecording();
+  }
+});


### PR DESCRIPTION
## Summary
- enable recording and download permissions for the auto scroller extension
- capture and save a WebM recording while the extension scrolls the requested page
- document the recording workflow and the need to keep the popup open until the download starts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dff69de48331a7c32ecf7ebaeb99